### PR TITLE
feat: save users with lat/lon to a separate set in order to speed up the map page

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -45,5 +45,8 @@
   },
   "less": [
     "static/styles.less"
+  ],
+  "upgrades": [
+    "./upgrades/osm-map-users-set.js"
   ]
 }

--- a/upgrades/osm-map-users-set.js
+++ b/upgrades/osm-map-users-set.js
@@ -1,0 +1,29 @@
+'use strict';
+
+const batch = require.main.require('./src/batch');
+const db = require.main.require('./src/database');
+
+module.exports = {
+	// you should use spaces
+	// the underscores are there so you can double click to select the whole thing
+	name: '[OSM Map] Add users with location to their own set',
+	// remember, month is zero-indexed (so January is 0, December is 11)
+	timestamp: Date.UTC(2021, 6, 2),
+	method: async function () {
+		const user = require.main.require('./src/user');
+		const { progress } = this;
+
+		await batch.processSortedSet('users:joindate', async (uids) => {
+			progress.incr(uids.length);
+
+			const addUids = (await user.getUsersFields(uids, ['locationLon', 'locationLat']))
+				.filter(user => !!user.locationLon && !!user.locationLat)
+				.map(user => user.uid);
+
+			await db.setAdd('osmMap.users', addUids);
+		}, {
+			batch: 500,
+			progress: this.progress,
+		});
+	},
+};


### PR DESCRIPTION
@RoPP We have a client with over 15,000 users registered, and this plugin will loop through the entire `users:joindate` zset every time the map page is loaded.

This pull request will save users with a valid lat/lon to a separate set, and query that on map page load.